### PR TITLE
fixes #96 / Fixed support for Cosmo-Multi-2 controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,9 @@ Save the file and restart the adapter, you will find now a new object Rueckkuehl
 ## Todo
 
 ## Changelog
+### v1.1.4 (2022-04-28)
+* (grizzelbee) New: [#96](https://github.com/Grizzelbee/ioBroker.resol/issues/96) Fixed Cosmo-Multi-2 support (Faking a DeltaSol-E now)
+
 ### v1.1.3 (2022-04-28)
 * (grizzelbee) New: [#96](https://github.com/Grizzelbee/ioBroker.resol/issues/96) Fixed Cosmo-Multi-2 support (Faking a DeltaSol-E now)
 

--- a/io-package.json
+++ b/io-package.json
@@ -1,9 +1,9 @@
 {
     "common": {
         "name": "resol",
-        "version": "1.1.3",
+        "version": "1.1.4",
         "news": {
-            "1.1.3": {
+            "1.1.4": {
                 "en": "Fixed support for Cosmo Multi 2 controllers",
                 "de": "Die Unterstützung für Cosmo Multi 2-Controller wurde korrigiert",
                 "ru": "Исправлена ​​поддержка контроллеров Cosmo Multi 2.",

--- a/lib/resol-setup/cosmo-multi-2.js
+++ b/lib/resol-setup/cosmo-multi-2.js
@@ -1,6 +1,4 @@
-{"dp": [{"dpName":"AutoRueckkuehl", "name":"Automatic cool down of buffer.","type":"number","min":0,"max":1, "states":{"0":"Off","1":"On"}},
-	{"dpName":"THolyCool", "name":"Temp. cooling buffer","type":"number","min":0,"max":800}
+{"dp": [{"dpName":"AutoRueckkuehl", "name":"Automatic cool down of buffer.","type":"number","min":0,"max":1, "states":{"0":"Off","1":"On"}}
 ],
-	"fct": [{"name":"AutoRueckkuehl","cmds":[{"cmd":"ORueckkuehlung","val":"val"},{"cmd":"OHolyCool","val":"val"}]},
-	{"name":"THolyCool","cmd":"THolyCool","val":"val"}
+	"fct": [{"name":"AutoRueckkuehl","cmds":[{"cmd":"ORueckkuehlung","val":"val"},{"cmd":"OHolyCool","val":"val"}]}
 ]}

--- a/lib/resol-setup/deltasol-e-v2.js
+++ b/lib/resol-setup/deltasol-e-v2.js
@@ -1,6 +1,4 @@
-{"dp": [{"dpName":"AutoRueckkuehl", "name":"Automatic cool down of buffer.","type":"number","min":0,"max":1, "states":{"0":"Off","1":"On"}},
-	{"dpName":"THolyCool", "name":"Temp. cooling buffer","type":"number","min":0,"max":800}
+{"dp": [{"dpName":"AutoRueckkuehl", "name":"Automatic cool down of buffer.","type":"number","min":0,"max":1, "states":{"0":"Off","1":"On"}}
 ],
-	"fct": [{"name":"AutoRueckkuehl","cmds":[{"cmd":"ORueckkuehlung","val":"val"},{"cmd":"OHolyCool","val":"val"}]},
-	{"name":"THolyCool","cmd":"THolyCool","val":"val"}
+	"fct": [{"name":"AutoRueckkuehl","cmds":[{"cmd":"ORueckkuehlung","val":"val"},{"cmd":"OHolyCool","val":"val"}]}
 ]}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "iobroker.resol",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "iobroker.resol",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "license": "MIT",
       "dependencies": {
         "@iobroker/adapter-core": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iobroker.resol",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Support for Resol VBus devices",
   "author": {
     "name": "grizzelbee",


### PR DESCRIPTION
### v1.1.4 (2022-04-28)
* (grizzelbee) New: [#96](https://github.com/Grizzelbee/ioBroker.resol/issues/96) Fixed Cosmo-Multi-2 support (Faking a DeltaSol-E now)
